### PR TITLE
Update ZYThumbnailTableViewController.swift and TopView.swift

### DIFF
--- a/ZYThumbnailTableView/Classes/Swift/ZYThumbnailTableViewController.swift
+++ b/ZYThumbnailTableView/Classes/Swift/ZYThumbnailTableViewController.swift
@@ -154,7 +154,7 @@ class ZYThumbnailTableViewController: UIViewController, UITableViewDataSource, U
     }
     
     func registerNotification() {
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "dismissPreview", name: NOTIFY_NAME_DISMISS_PREVIEW, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(dismissPreview), name: NOTIFY_NAME_DISMISS_PREVIEW, object: nil)
     }
     
     func resignNotification() {
@@ -593,7 +593,7 @@ extension UIView {
     
     func screenShot() -> UIImage {
         UIGraphicsBeginImageContext(self.bounds.size)
-        if self.respondsToSelector("drawViewHierarchyInRect:afterScreenUpdates:") {
+        if self.respondsToSelector(#selector(drawViewHierarchyInRect:afterScreenUpdates) {
             //ios7以上
             self.drawViewHierarchyInRect(self.frame, afterScreenUpdates: false)
         } else {

--- a/ZYThumbnailTableView/DiyViews/TopView.swift
+++ b/ZYThumbnailTableView/DiyViews/TopView.swift
@@ -85,7 +85,7 @@ class TopView: UIView {
         
         //notification
         let notification = NSNotification(name: "NOTIFY_NAME_DISMISS_PREVIEW", object: nil)
-        NSNotificationCenter.defaultCenter().performSelector("postNotification:", withObject: notification, afterDelay: 0.25)
+        NSNotificationCenter.defaultCenter().performSelector(#selector(postNotification), withObject: notification, afterDelay: 0.25)
         
         //delegate
         if let nonNilDelegate = delegate {
@@ -109,7 +109,7 @@ class TopView: UIView {
         
         //notification
         let notification = NSNotification(name: "NOTIFY_NAME_DISMISS_PREVIEW", object: nil)
-        NSNotificationCenter.defaultCenter().performSelector("postNotification:", withObject: notification, afterDelay: 0.25)
+        NSNotificationCenter.defaultCenter().performSelector(#selector(postNotification), withObject: notification, afterDelay: 0.25)
         
         //delegate
         if let nonNilDelegate = delegate {


### PR DESCRIPTION
Update to iOS 9.3 selector() syntax.
